### PR TITLE
change notation for slack variables

### DIFF
--- a/ml-svm.tex
+++ b/ml-svm.tex
@@ -2,4 +2,6 @@
 \newcommand{\sv}{\operatorname{SV}}                                         % supportvectors
 % already defined in basic-math:
 % \newcommand{\HS}{\mathcal{H}}                                               % H, hilbertspace
-\let\myxi\xi																% xi, slack variable (SVM)
+\newcommand{\sl}{\zeta}
+\newcommand{\slvec}{\left(\zeta^{(1)}, \zeta^{(n)}\right)}		% slack variables (SVM)
+\newcommand{\sli}{\zeta^{(i)}}																% slack variable (SVM)


### PR DESCRIPTION
calling them xi makes them look too similar to the feature vectors (almost identical, except of the additional subscript that was added manually  -- on the slides, it was $x^{(i)}_i$.

zeta is often used in the literature and is more distinct from the feature vectors